### PR TITLE
Containerize lossbot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.9-slim-buster
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+COPY . .
+
+CMD [ "python3", "bot.py" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+torch == 1.10.2
+torchvision == 0.11.3
+pillow == 9.0.1
+discord.py == 1.7.3
+numpy == 1.21.5
+python-dotenv == 0.19.2


### PR DESCRIPTION
Given the trained model weights and Discord token, allow lossbot to run inside a Docker container.
Build container with `docker build --tag lossbot .` and run with `docker run -d lossbot:latest`